### PR TITLE
Add custom events + create composer package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Allow to send token email (invite or reminder) via PHP cli . This allow to use c
 - Clone in plugins/sendMailCron directory
 
 ### Via ZIP dowload
-- Get the file [sendMailCron.zip](http://extensions.sondages.pro/IMG/auto/sendMailCron.zip) (If you use LimeSurvey 2.54.4 or up)
+- Get the file [sendMailCron.zip](https://extensions.sondages.pro/IMG/auto/sendMailCron.zip) (If you use LimeSurvey 2.54.4 or up)
 - Extract : `unzip sendMailCron.zip`
 - Move the directory to plugins/ directory inside LimeSUrvey
-- If you use LimeSurvey 2.54.3 or below : use [sendMailCron_2.6lts_compat.zip](http://extensions.sondages.pro/IMG/auto/sendMailCron_2.6lts_compat.zip)
+- If you use LimeSurvey 2.54.3 or below : use [sendMailCron_2.6lts_compat.zip](https://extensions.sondages.pro/IMG/auto/sendMailCron_2.6lts_compat.zip)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Plugin use 2 system for logging :
       ),
   ````
 
+### Events
+
+The plugin dispatch two custom events.
+- When the cron finished to sent emails for a survey of a specific type (invite / reminder) `finishSendEmailsForSurveyTypeCron`
+- When the cron finished to sent emails for a survey `finishSendEmailForSurveyCron`
+
 ## Contribute
 
 Issue and merge request are welcome on [framagit](https://framagit.org/SondagePro-LimeSurvey-plugin/sendMailCron) or [github](https://github.com/SondagesPro/LS-sendMailCron/).

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "SondagesPro/sendMailCron",
+    "description": "Allow to send token email (invite or reminder) via PHP cli . This allow to use crontab or Scheduled task to send email.",
+    "type": "limesurvey-plugin",
+    "homepage": "https://github.com/SondagesPro/LS-sendMailCron",
+    "license": "AGPL-3.0+",
+    "authors": [
+        {
+            "name": "Denis Chenu",
+            "email": "contact@sondages.pro"
+        }
+    ],
+    "minimum-stability": "stable",
+    "require": {}
+}


### PR DESCRIPTION
Add two new events that can be listen:
- When the cron finished to sent emails for a survey of a specific type (invite / reminder) `finishSendEmailsForSurveyTypeCron`
- When the cron finished to sent emails for a survey `finishSendEmailForSurveyCron`

Theses event let us more flexibility for complementary plugins

I add a `composer.json` file for packaging the plugin

Maybe we could tag the `2.2.0` and new `2.3.0` version ?